### PR TITLE
Fix GitHub Actions workflow by using PHP 7.4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '7.4'
           extensions: mbstring, json
           coverage: none
 


### PR DESCRIPTION
The composer.lock file contains packages that require PHP ^7.1.3 (Laravel/Illuminate 5.8) which are not compatible with PHP 8.1. Changed the workflow to use PHP 7.4 to match the locked dependency versions.

Fixes the "Your lock file does not contain a compatible set of packages" error.