### PR TITLE
Fix npm installation issues in GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,11 +38,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '16'
           cache: 'npm'
 
       - name: Install npm dependencies
-        run: npm ci
+        run: npm install --legacy-peer-deps
 
       - name: Build Jigsaw site
         run: ./vendor/bin/jigsaw build production


### PR DESCRIPTION
Changes made:
- Downgrade Node.js from 18 to 16 for better compatibility with old dependencies (Laravel Mix 4.0, etc.)
- Replace 'npm ci' with 'npm install --legacy-peer-deps' to handle peer dependency conflicts
- The --legacy-peer-deps flag allows installation of packages with incompatible peer dependencies

These old packages from 2019 were not designed for Node 18 and have peer dependency issues.