### PR TITLE
Fix out-of-memory error during asset compilation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Compile assets
         run: npm run production
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
Exit code 9 indicates Node.js ran out of memory during webpack compilation. Added NODE_OPTIONS environment variable to increase Node.js memory limit to 4GB for the asset compilation step.

This should allow Laravel Mix/Webpack to complete the build process without running out of memory.