### PR TITLE
Fix GitHub Actions deployment workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
     "private": true,
     "scripts": {
-        "local": "cross-env NODE_ENV=development NODE_OPTIONS=--openssl-legacy-provider node_modules/webpack/bin/webpack.js --progress --hide-modules --env=local --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "staging": "cross-env NODE_ENV=staging NODE_OPTIONS=--openssl-legacy-provider node_modules/webpack/bin/webpack.js --progress --hide-modules --env=staging --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "production": "cross-env NODE_ENV=production NODE_OPTIONS=--openssl-legacy-provider node_modules/webpack/bin/webpack.js --progress --hide-modules --env=production --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "local": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --env=local --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "staging": "cross-env NODE_ENV=staging node_modules/webpack/bin/webpack.js --progress --hide-modules --env=staging --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --env=production --config=node_modules/laravel-mix/setup/webpack.config.js",
         "dev": "npm run local",
         "watch": "npm run local -- --watch"
     },


### PR DESCRIPTION
Fixed multiple issues preventing successful deployment:

1. Removed NODE_OPTIONS=--openssl-legacy-provider from package.json scripts
   - The --openssl-legacy-provider flag cannot be set via NODE_OPTIONS environment variable
   - This was causing "node: --openssl-legacy-provider is not allowed in NODE_OPTIONS" error

2. Updated workflow to use Node.js 16 instead of 18
   - Old dependencies (Laravel Mix 4.0, 2019 packages) are not compatible with Node 18
   - Node 16 provides better compatibility

3. Changed npm ci to npm install --legacy-peer-deps
   - Handles peer dependency conflicts in old packages
   - More forgiving installation process

4. Added NODE_OPTIONS: --max_old_space_size=4096 for asset compilation
   - Increases Node.js memory limit to 4GB to prevent OOM errors
   - Allows webpack to complete asset compilation without running out of memory

These changes should allow the workflow to successfully build and deploy to GitHub Pages.