### PR TITLE
Fix missing resources by updating baseUrl for GitHub Pages

### DIFF
--- a/config.production.php
+++ b/config.production.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'baseUrl' => 'https://www.khanh.page',
+    'baseUrl' => 'https://godstorm91.github.io/khanh.page',
     'production' => true,
 ];


### PR DESCRIPTION
Changed baseUrl from 'https://www.khanh.page' to 'https://godstorm91.github.io/khanh.page' to match the actual GitHub Pages deployment URL.

This fixes the issue where CSS, JavaScript, and image assets were not loading because they were being referenced from the wrong base URL.