### PR TITLE
Fix all asset and navigation paths to use baseUrl

### DIFF
--- a/source/_layouts/master.blade.php
+++ b/source/_layouts/master.blade.php
@@ -14,8 +14,8 @@
         <title>{{ $page->siteName }}{{ $page->title ? ' | ' . $page->title : '' }}</title>
 
         <link rel="home" href="{{ $page->baseUrl }}">
-        <link rel="icon" href="/favicon.ico">
-        <link href="/blog/feed.atom" type="application/atom+xml" rel="alternate" title="{{ $page->siteName }} Atom Feed">
+        <link rel="icon" href="{{ $page->baseUrl }}/favicon.ico">
+        <link href="{{ $page->baseUrl }}/blog/feed.atom" type="application/atom+xml" rel="alternate" title="{{ $page->siteName }} Atom Feed">
 
         @stack('meta')
 
@@ -24,7 +24,7 @@
         @endif
 
         <link href="https://fonts.googleapis.com/css?family=Nunito+Sans:300,300i,400,400i,700,700i,800,800i" rel="stylesheet">
-        <link rel="stylesheet" href="{{ mix('css/main.css', 'assets/build') }}">
+        <link rel="stylesheet" href="{{ $page->baseUrl }}{{ mix('css/main.css', 'assets/build') }}">
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-76723458-7"></script>
 <script>
@@ -41,8 +41,8 @@
         <header class="flex items-center shadow bg-grey-darkest border-b border-grey-darker h-24 py-4" role="banner">
             <div class="container flex items-center max-w-4xl mx-auto px-4 lg:px-8">
                 <div class="flex items-center">
-                    <a href="/" title="{{ $page->siteName }} home" class="inline-flex items-center">
-                        <img class="h-8 md:h-10 mr-3" src="/assets/img/logo.svg" alt="{{ $page->siteName }} logo" />
+                    <a href="{{ $page->baseUrl }}" title="{{ $page->siteName }} home" class="inline-flex items-center">
+                        <img class="h-8 md:h-10 mr-3" src="{{ $page->baseUrl }}/assets/img/logo.svg" alt="{{ $page->siteName }} logo" />
 
                         <h1 class="text-lg md:text-2xl text-purple-light font-semibold hover:text-pink my-0">{{ $page->siteName }}</h1>
                     </a>
@@ -77,7 +77,7 @@
             </ul>
         </footer>
 
-        <script src="{{ mix('js/main.js', 'assets/build') }}"></script>
+        <script src="{{ $page->baseUrl }}{{ mix('js/main.js', 'assets/build') }}"></script>
 
         @stack('scripts')
     </body>

--- a/source/_nav/menu-responsive.blade.php
+++ b/source/_nav/menu-responsive.blade.php
@@ -3,21 +3,21 @@
         <li class="pl-4">
             <a
                 title="{{ $page->siteName }} Blog"
-                href="/blog"
+                href="{{ $page->baseUrl }}/blog"
                 class="nav-menu__item hover:text-blue {{ $page->isActive('/blog') ? 'active text-blue' : '' }}"
             >Blog</a>
         </li>
         <li class="pl-4">
             <a
                 title="{{ $page->siteName }} About"
-                href="/about"
+                href="{{ $page->baseUrl }}/about"
                 class="nav-menu__item hover:text-blue {{ $page->isActive('/about') ? 'active text-blue' : '' }}"
             >About</a>
         </li>
         <li class="pl-4">
             <a
                 title="{{ $page->siteName }} Contact"
-                href="/contact"
+                href="{{ $page->baseUrl }}/contact"
                 class="nav-menu__item hover:text-blue {{ $page->isActive('/contact') ? 'active text-blue' : '' }}"
             >Contact</a>
         </li>

--- a/source/_nav/menu.blade.php
+++ b/source/_nav/menu.blade.php
@@ -1,15 +1,15 @@
 <nav class="hidden lg:flex items-center justify-end text-lg">
-    <a title="{{ $page->siteName }} Blog" href="/blog"
+    <a title="{{ $page->siteName }} Blog" href="{{ $page->baseUrl }}/blog"
         class="ml-6 text-grey-darker hover:text-blue-dark {{ $page->isActive('/blog') ? 'active text-blue-dark' : '' }}">
         Blog
     </a>
 
-    <a title="{{ $page->siteName }} About" href="/about"
+    <a title="{{ $page->siteName }} About" href="{{ $page->baseUrl }}/about"
         class="ml-6 text-grey-darker hover:text-blue-dark {{ $page->isActive('/about') ? 'active text-blue-dark' : '' }}">
         About
     </a>
 
-    <a title="{{ $page->siteName }} Contact" href="/contact"
+    <a title="{{ $page->siteName }} Contact" href="{{ $page->baseUrl }}/contact"
         class="ml-6 text-grey-darker hover:text-blue-dark {{ $page->isActive('/contact') ? 'active text-blue-dark' : '' }}">
         Contact
     </a>

--- a/source/about.blade.php
+++ b/source/about.blade.php
@@ -10,7 +10,7 @@
 @section('body')
     <h1>About</h1>
 
-    <img src="/assets/img/about.jpg"
+    <img src="{{ $page->baseUrl }}/assets/img/about.jpg"
         alt="About image"
         class="flex rounded-full h-64 w-64 bg-contain mx-auto md:float-right my-6 md:ml-10">
 


### PR DESCRIPTION
Fixed the issue where resources were not loading on GitHub Pages subdirectory deployment by prefixing all paths with {{ $page->baseUrl }}.

Changes:
- Updated master.blade.php:
  * Added baseUrl to favicon.ico path
  * Added baseUrl to blog feed.atom path
  * Added baseUrl to CSS (main.css) via mix() helper
  * Added baseUrl to JS (main.js) via mix() helper
  * Added baseUrl to logo.svg image
  * Fixed home link to use baseUrl

- Updated about.blade.php:
  * Added baseUrl to about.jpg image path

- Updated menu.blade.php:
  * Added baseUrl to /blog navigation link
  * Added baseUrl to /about navigation link
  * Added baseUrl to /contact navigation link

- Updated menu-responsive.blade.php:
  * Added baseUrl to all navigation links (blog, about, contact)

This ensures all assets (CSS, JS, images) and navigation links work correctly when deployed to https://godstorm91.github.io/khanh.page/