### PR TITLE
Improve blog title contrast with Dracula pink color

### DIFF
--- a/source/_components/post-preview-inline.blade.php
+++ b/source/_components/post-preview-inline.blade.php
@@ -7,7 +7,7 @@
         <a
             href="{{ $post->getUrl() }}"
             title="Read more - {{ $post->title }}"
-            class="text-black font-extrabold"
+            class="text-pink font-extrabold"
         >{{ $post->title }}</a>
     </h2>
 

--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -12,7 +12,7 @@
             </p>
 
             <h2 class="text-3xl mt-0">
-                <a href="{{ $featuredPost->getUrl() }}" title="Read {{ $featuredPost->title }}" class="text-black font-extrabold">
+                <a href="{{ $featuredPost->getUrl() }}" title="Read {{ $featuredPost->title }}" class="text-pink font-extrabold">
                     {{ $featuredPost->title }}
                 </a>
             </h2>


### PR DESCRIPTION
Changed blog post title color from text-black to text-pink (#FF79C6) for better visibility and contrast in the Dracula theme. This affects both featured posts on the homepage and regular post previews.