### PR TITLE
Upgrade typography with Inter and JetBrains Mono fonts

### DIFF
--- a/source/_layouts/master.blade.php
+++ b/source/_layouts/master.blade.php
@@ -23,7 +23,7 @@
             <!-- Insert analytics code here -->
         @endif
 
-        <link href="https://fonts.googleapis.com/css?family=Nunito+Sans:300,300i,400,400i,700,700i,800,800i" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="{{ $page->baseUrl }}{{ mix('css/main.css', 'assets/build') }}">
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-76723458-7"></script>

--- a/tailwind.js
+++ b/tailwind.js
@@ -195,7 +195,7 @@ screens: {
 
 fonts: {
   'sans': [
-    'Nunito Sans',
+    'Inter',
     'system-ui',
     'BlinkMacSystemFont',
     '-apple-system',
@@ -222,6 +222,7 @@ fonts: {
     'serif',
   ],
   'mono': [
+    'JetBrains Mono',
     'Menlo',
     'Monaco',
     'Consolas',


### PR DESCRIPTION
Replace Nunito Sans with Inter for improved readability in body text, and add JetBrains Mono as the primary monospace font for better code display. Both fonts are loaded from Google Fonts with appropriate weights.